### PR TITLE
Update deploy.json

### DIFF
--- a/.bluemix/deploy.json
+++ b/.bluemix/deploy.json
@@ -1,9 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Sample Deploy Stage",
-    "localized-struct":{
-        "$ref": "deploy-localized-struct.json"
-    },
     "description": "sample toolchain",
     "longDescription": "The Delivery Pipeline automates continuous deployment.",
     "type": "object",


### PR DESCRIPTION
This repository currently fails to load in the Devops UI:

<img width="713" alt="screen shot 2017-04-25 at 9 10 46 pm" src="https://cloud.githubusercontent.com/assets/382404/25413887/d107c3a0-29fb-11e7-85b3-06856716477d.png">

The cause is a reference in `deploy.json` to a missing file `deploy-localized-struct.json`. Previous versions of the UI would've tolerated this, but it's become stricter since then.

This pull request removes the reference to the missing file and allows the template to work again.